### PR TITLE
Provide a up to date version of Maven

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ runs:
         java-version: ${{ inputs.java-version }}
         distribution: 'temurin'
         cache: 'maven'
+    - name: 'Setup Maven'
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.9
     - name: 'Maven Build'
       run: mvn ${{ inputs.goal }} --file ${{ inputs.pom }} --batch-mode -Dmaven.javadoc.skip=${{ inputs.skip-javadoc }} -V --no-transfer-progress
       shell: bash


### PR DESCRIPTION
Provide a more recent version of Maven, as some projects need Maven 3.9.x already.